### PR TITLE
Add QQ and Kugou lyrics providers with cache tables

### DIFF
--- a/migrations/0011_add_qq_and_kugou_cache.sql
+++ b/migrations/0011_add_qq_and_kugou_cache.sql
@@ -1,0 +1,18 @@
+-- Add QQ and Kugou Cache tables
+CREATE TABLE IF NOT EXISTS qq_lyrics_cache (
+  video_id TEXT NOT NULL,
+  source_platform TEXT NOT NULL CHECK(source_platform IN ('youtube_music', 'spotify', 'apple_music')),
+  r2_key TEXT NOT NULL,
+  last_accessed_at INTEGER NOT NULL,
+  last_updated_at INTEGER NOT NULL,
+  PRIMARY KEY (video_id, source_platform)
+);
+
+CREATE TABLE IF NOT EXISTS kugou_lyrics_cache (
+  video_id TEXT NOT NULL,
+  source_platform TEXT NOT NULL CHECK(source_platform IN ('youtube_music', 'spotify', 'apple_music')),
+  r2_key TEXT NOT NULL,
+  last_accessed_at INTEGER NOT NULL,
+  last_updated_at INTEGER NOT NULL,
+  PRIMARY KEY (video_id, source_platform)
+);

--- a/src/LyricUtils.ts
+++ b/src/LyricUtils.ts
@@ -47,11 +47,3 @@ export function parseLrc(lrcText: string) {
 
     return result;
 }
-
-export interface LyricsResponse {
-    ttml: string | null;
-    richSynced: string | null;
-    synced: string | null | undefined;
-    unsynced: string | null;
-    debugInfo: any;
-}

--- a/src/endpoints/Lyrics.ts
+++ b/src/endpoints/Lyrics.ts
@@ -79,7 +79,7 @@ export class Lyrics extends OpenAPIRoute {
 
             const response = c.json(result, 200, corsHeaders);
 
-            if (result.musixmatchSyncedLyrics || result.lrclibSyncedLyrics || result.goLyricsApiTtml) {
+            if (result.musixmatchSyncedLyrics || result.lrclibSyncedLyrics || result.goLyricsApiLyrics || result.qqLyricsApiLyrics || result.kugouLyricsApiLyrics) {
                 response.headers.set('Cache-control', 'public; max-age=1080');
             } else {
                 response.headers.set("Cache-control", "public; max-age=600");

--- a/src/providers/BoiduLyricsApi.ts
+++ b/src/providers/BoiduLyricsApi.ts
@@ -1,33 +1,39 @@
 import { addAwait, observe } from '../observability';
-import { LyricsResponse } from '../LyricUtils';
-import { CacheService } from '../services/CacheService';
+import { CacheService, SaveLyricsData, SourcePlatform } from '../services/CacheService';
 import { Env } from '../types';
 
 const Constants = {
     LYRICS_API_URL: 'https://lyrics-api.boidu.dev/getLyrics'
 }
 
-export interface GoLyricsApiParameters {
+export interface BoiduLyricsApiParameters {
     song: string;
     artist: string;
     album: string | null;
     duration: string;
 }
 
-const DEFAULT_REFETCH_THRESHOLD = 1 * 86400;
-const DEFAULT_REFETCH_CHANCE = 0.2;
+const DEFAULT_REFETCH_THRESHOLD = 2 * 86400;
+const DEFAULT_REFETCH_CHANCE = 0.15;
+export interface BoiduLyrics {
+    lyrics: string | null;
+}
 
-export class GoLyricsApi {
-    private readonly ROOT_URL = Constants.LYRICS_API_URL;
+
+export class BoiduLyricsApi {
+    private readonly ROOT_URL: string;
+    private readonly sourceName: SourcePlatform;
     private cacheService: CacheService;
     private env: Env;
 
-    constructor(env: Env) {
+    constructor(env: Env, sourceName: SourcePlatform = 'golyrics', endpointUrl: string = Constants.LYRICS_API_URL) {
         this.env = env;
         this.cacheService = new CacheService(env);
+        this.sourceName = sourceName;
+        this.ROOT_URL = endpointUrl;
     }
 
-    private async _get(providerParameters: GoLyricsApiParameters): Promise<Response> {
+    private async _get(providerParameters: BoiduLyricsApiParameters): Promise<Response> {
         const url = new URL(this.ROOT_URL);
         url.searchParams.append("s", providerParameters.song);
         url.searchParams.append("a", providerParameters.artist);
@@ -54,25 +60,35 @@ export class GoLyricsApi {
         let keys = [...newResponse.headers.keys()];
         keys.forEach((key) => newResponse.headers.delete(key));
 
-        observe({'goLyricsApi': {responseStatus: response.status }});
-
-
+        observe({ [`${this.sourceName}Api`]: { responseStatus: response.status } });
 
         return new Response(teeBody[0], newResponse);
     }
 
-    private async fetchAndSave(videoId: string, providerParameters: GoLyricsApiParameters): Promise<LyricsResponse | null> {
+    private async getCache(sourcePlatform: SourcePlatform, videoId: string) {
+        if (this.sourceName === 'qq') return this.cacheService.getQqLyrics(sourcePlatform, videoId);
+        if (this.sourceName === 'kugou') return this.cacheService.getKugouLyrics(sourcePlatform, videoId);
+        return this.cacheService.getGoLyrics(sourcePlatform, videoId);
+    }
+
+    private async saveCache(data: SaveLyricsData) {
+        if (this.sourceName === 'qq') return this.cacheService.saveQqLyrics(data);
+        if (this.sourceName === 'kugou') return this.cacheService.saveKugouLyrics(data);
+        return this.cacheService.saveGoLyrics(data);
+    }
+
+    private async fetchAndSave(videoId: string, providerParameters: BoiduLyricsApiParameters): Promise<BoiduLyrics | null> {
         const response = await this._get(providerParameters);
 
         if (response.status !== 200) {
             observe({
-                goLyricsApiError: {
+                [`${this.sourceName}ApiError`]: {
                     'invalidStatusCode': response.status,
                     body: await response.text(),
                 }
             });
             if (response.status === 404) {
-                 addAwait(this.cacheService.saveNegative('golyrics', videoId));
+                addAwait(this.cacheService.saveNegative(this.sourceName, videoId));
             }
             return null;
         }
@@ -81,7 +97,7 @@ export class GoLyricsApi {
 
         if (ttml) {
             addAwait(
-                this.cacheService.saveGoLyrics({
+                this.saveCache({
                     source_track_id: videoId,
                     source_platform: "youtube_music",
                     lyric_format: "ttml",
@@ -90,25 +106,21 @@ export class GoLyricsApi {
             );
 
             addAwait(this.env.DB.prepare("DELETE FROM negative_mappings WHERE source_platform = ?1 AND source_track_id = ?2")
-                .bind('golyrics', videoId).run());
+                .bind(this.sourceName, videoId).run());
 
         } else {
-             addAwait(this.cacheService.saveNegative('golyrics', videoId));
+            addAwait(this.cacheService.saveNegative(this.sourceName, videoId));
         }
 
         return {
-            ttml: ttml,
-            richSynced: null,
-            synced: null,
-            unsynced: null,
-            debugInfo: null
+            lyrics: ttml
         };
     }
 
-    async getLrc(videoId: string, providerParameters: GoLyricsApiParameters): Promise<LyricsResponse | null> {
+    async getLrc(videoId: string, providerParameters: BoiduLyricsApiParameters): Promise<BoiduLyrics | null> {
 
         // 1. Check Negative Cache
-        const negativeStatus = await this.cacheService.getNegative('golyrics', videoId);
+        const negativeStatus = await this.cacheService.getNegative(this.sourceName, videoId);
         if (negativeStatus.hit) {
             if (negativeStatus.stale) {
                 // SWR: Return null, but fetch in background
@@ -118,7 +130,7 @@ export class GoLyricsApi {
         }
 
         // 2. Check Positive Cache
-        let cachedData = await this.cacheService.getGoLyrics("youtube_music", videoId);
+        let cachedData = await this.getCache("youtube_music", videoId);
         let shouldRefetch = false;
 
         if (cachedData) {
@@ -129,13 +141,13 @@ export class GoLyricsApi {
             if (now - cachedData.lastUpdatedAt > threshold) {
                 if (Math.random() < chance) {
                     shouldRefetch = true;
-                    observe({ 'goLyricsCacheRefetch': true });
+                    observe({ [`${this.sourceName}CacheRefetch`]: true });
                 }
             }
 
             if (shouldRefetch) {
-                 // SWR: Use cached data, but fetch in background
-                 addAwait(this.fetchAndSave(videoId, providerParameters));
+                // SWR: Use cached data, but fetch in background
+                addAwait(this.fetchAndSave(videoId, providerParameters));
             }
 
             // Return cached data
@@ -146,13 +158,7 @@ export class GoLyricsApi {
                 }
             }
             return {
-                ttml: ttml,
-                richSynced: null,
-                synced: null,
-                unsynced: null,
-                debugInfo: {
-                    comment: 'goLyricsApi cache'
-                }
+                lyrics: ttml
             };
         }
 

--- a/src/providers/LrcLib.ts
+++ b/src/providers/LrcLib.ts
@@ -1,4 +1,3 @@
-import { LyricsResponse } from '../LyricUtils';
 import { observe, addAwait } from '../observability';
 import { CacheService } from '../services/CacheService';
 import { Env } from '../types';
@@ -16,6 +15,11 @@ export interface LrcLibResponse {
     syncedLyrics: string;
 }
 
+export interface LrcLibLyrics {
+    synced: string | null;
+    unsynced: string | null;
+}
+
 export class LrcLib {
     private cacheService: CacheService;
     private env: Env;
@@ -25,7 +29,7 @@ export class LrcLib {
         this.cacheService = new CacheService(env);
     }
 
-    private async fetchAndSave(videoId: string, artist: string, song: string, album: string | null, duration: string | null | undefined): Promise<LyricsResponse | null> {
+    private async fetchAndSave(videoId: string, artist: string, song: string, album: string | null, duration: string | null | undefined): Promise<LrcLibLyrics | null> {
         let fetchUrl = new URL(LRCLIB_API);
         fetchUrl.searchParams.append('artist_name', artist);
         fetchUrl.searchParams.append('track_name', song);
@@ -70,11 +74,8 @@ export class LrcLib {
             }
 
             return {
-                richSynced: null,
                 synced: json.syncedLyrics,
-                unsynced: json.plainLyrics,
-                debugInfo: null,
-                ttml: null
+                unsynced: json.plainLyrics
             };
         } catch (err) {
             observe({ 'lrclibError': err });
@@ -82,7 +83,7 @@ export class LrcLib {
         }
     }
 
-    async getLyrics(videoId: string, artist: string, song: string, album: string | null, duration: string | null | undefined): Promise<LyricsResponse | null> {
+    async getLyrics(videoId: string, artist: string, song: string, album: string | null, duration: string | null | undefined): Promise<LrcLibLyrics | null> {
         // 1. Check Negative Cache
         const negativeStatus = await this.cacheService.getNegative('lrclib', videoId);
         if (negativeStatus.hit) {
@@ -114,11 +115,8 @@ export class LrcLib {
             }
 
             return {
-                richSynced: null,
                 synced: cachedData.synced,
-                unsynced: cachedData.unsynced,
-                debugInfo: { comment: 'lrclib cache' },
-                ttml: null
+                unsynced: cachedData.unsynced
             };
         }
 

--- a/src/providers/Musixmatch.ts
+++ b/src/providers/Musixmatch.ts
@@ -1,8 +1,8 @@
 // Types for our responses and data
 import { addAwait, observe } from '../observability';
 import { diffArrays } from 'diff';
-import { LyricsResponse, parseLrc } from '../LyricUtils';
-import { CacheService, Lyric } from '../services/CacheService';
+import { parseLrc } from '../LyricUtils';
+import { CacheService } from '../services/CacheService';
 import { Env } from '../types';
 
 interface MusixmatchResponse {
@@ -128,6 +128,11 @@ export interface MatchingTimedWord {
      */
     word: string;
     wordTime: number;
+}
+
+export interface MusixmatchLyrics {
+    richSynced: string | null;
+    synced: string | null;
 }
 
 // These fields can persist through multiple requests to the API
@@ -266,16 +271,16 @@ export class Musixmatch {
         return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}.${hundredths.toString().padStart(2, '0')}`;
     }
 
-    private async getLrcWordByWord(trackId: string | number, lrcLyrics: Promise<LyricsResponse | null | void> | null):
-        Promise<LyricsResponse | null> {
+    private async getLrcWordByWord(trackId: string | number, lrcLyrics: Promise<any | null | void> | null):
+        Promise<MusixmatchLyrics | null> {
 
 
-        let musixmatchBasicLyrics: Promise<LyricsResponse | null> = this.getLrcById(trackId);
-        let basicLrcPromise: Promise<LyricsResponse | null | void>;
+        let musixmatchBasicLyricsPromise = this.getLrcById(trackId);
+        let basicLrcPromise: Promise<any | null | void>;
         if (lrcLyrics !== null) {
             basicLrcPromise = lrcLyrics;
         } else {
-            basicLrcPromise = musixmatchBasicLyrics;
+            basicLrcPromise = musixmatchBasicLyricsPromise;
         }
         const response = await this._get('track.richsync.get', [['track_id', String(trackId)]]);
         const data = await response.json() as MusixmatchResponse;
@@ -313,11 +318,13 @@ export class Musixmatch {
 
 
         let basicLrc = await basicLrcPromise;
-        if (basicLrc && basicLrc.synced) {
+        const synced = typeof basicLrc === 'string' ? basicLrc : (basicLrc && 'synced' in basicLrc ? basicLrc.synced : null);
+        
+        if (synced) {
             let basicLrcOffset = [] as number[];
             let diffDebug: { op: string, text: string }[] = [];
 
-            let parsedLrc = parseLrc(basicLrc.synced);
+            let parsedLrc = parseLrc(synced);
             let parsedLrcTokenArray: MatchingTimedWord[] = [];
             parsedLrc.forEach(({startTimeMs, words}, index) => {
                 let wordsSplit = words.split(' ');
@@ -347,9 +354,7 @@ export class Musixmatch {
 
             if (parsedLrcTokenArray.length > 5000 || richSyncTokenArray.length > 5000) {
                 return {
-                    richSynced: null, synced: (await musixmatchBasicLyrics)?.synced, unsynced: null, debugInfo: {
-                        comment: 'lyrics too long to diff'
-                    }, ttml: null
+                    richSynced: null, synced: (await musixmatchBasicLyricsPromise)?.synced || null
                 };
             }
             let diff = diffArrays(parsedLrcTokenArray, richSyncTokenArray, { comparator: (left, right) => left.word.toLowerCase() === right.word.toLowerCase() });
@@ -389,30 +394,23 @@ export class Musixmatch {
             if (variance < 1.5) {
                 lrcStr = `[offset:${addPlusSign(mean)}]\n` + lrcStr;
                 return {
-                    richSynced: lrcStr, synced: (await musixmatchBasicLyrics)?.synced, unsynced: null, debugInfo: {
-                        lyricMatchingStats: { mean, variance, samples: basicLrcOffset, diff: diffDebug }
-                    }, ttml: null
+                    richSynced: lrcStr, synced: (await musixmatchBasicLyricsPromise)?.synced || null
                 };
             } else {
                 return {
-                    richSynced: null, synced: (await musixmatchBasicLyrics)?.synced, unsynced: null, debugInfo: {
-                        lyricMatchingStats: { mean, variance, samples: basicLrcOffset, diff: diffDebug },
-                        comment: 'basic lyrics matched but variance is too high; using basic lyrics instead'
-                    }, ttml: null
+                    richSynced: null, synced: (await musixmatchBasicLyricsPromise)?.synced || null
                 };
             }
         }
 
         return {
-            richSynced: lrcStr, synced: null, unsynced: null, debugInfo: {
-                comment: 'no synced basic lyrics found'
-            }, ttml: null
+            richSynced: lrcStr, synced: null
         };
 
 
     }
 
-    private async getLrcById(trackId: string | number): Promise<LyricsResponse | null> {
+    private async getLrcById(trackId: string | number): Promise<MusixmatchLyrics | null> {
         // Get the main subtitles
         const response = await this._get('track.subtitle.get', [
             ['track_id', String(trackId)],
@@ -430,7 +428,7 @@ export class Musixmatch {
 
         let lrcStr = data.message.body.subtitle.subtitle_body;
 
-        return { richSynced: null, synced: lrcStr, unsynced: null, debugInfo: null, ttml: null };
+        return { richSynced: null, synced: lrcStr };
     }
 
     private async fetchAndSave(
@@ -438,9 +436,9 @@ export class Musixmatch {
         artist: string,
         track: string,
         album: string | null,
-        lrcLyrics: Promise<LyricsResponse | null | void> | null,
+        lrcLyrics: Promise<any | null | void> | null,
         tokenPromise: Promise<void>
-    ): Promise<LyricsResponse | null> {
+    ): Promise<MusixmatchLyrics | null> {
         await tokenPromise;
         observe({ 'musixMatchHasValidToken': token !== null });
         if (token === null) {
@@ -529,8 +527,8 @@ export class Musixmatch {
     }
 
 
-    async getLrc(videoId: string, artist: string, track: string, album: string | null, lrcLyrics: Promise<LyricsResponse | null | void> | null, tokenPromise: Promise<void>):
-        Promise<LyricsResponse | null> {
+    async getLrc(videoId: string, artist: string, track: string, album: string | null, lrcLyrics: Promise<any | null | void> | null, tokenPromise: Promise<void>):
+        Promise<MusixmatchLyrics | null> {
 
         // 1. Check Negative Cache
         const negativeStatus = await this.cacheService.getNegative('youtube_music', videoId);
@@ -576,10 +574,7 @@ export class Musixmatch {
             }
 
             return {
-                richSynced: richSynced, synced: normalSynced, unsynced: null, debugInfo: {
-                    lyricMatchingStats: null,
-                    comment: 'musixmatch cache'
-                }, ttml: null
+                richSynced: richSynced, synced: normalSynced
             };
         }
 

--- a/src/services/CacheService.ts
+++ b/src/services/CacheService.ts
@@ -3,7 +3,7 @@ import pako from 'pako';
 import { addAwait, observe } from '../observability';
 
 export type LyricType = 'rich_sync' | 'normal_sync' | 'ttml';
-export type SourcePlatform = 'youtube_music' | 'spotify' | 'apple_music' | 'musixmatch' | 'golyrics' | 'lrclib';
+export type SourcePlatform = 'youtube_music' | 'spotify' | 'apple_music' | 'musixmatch' | 'golyrics' | 'lrclib' | 'qq' | 'kugou';
 
 export interface Lyric {
     format: LyricType;
@@ -129,9 +129,10 @@ export class CacheService {
         }
     }
 
-    async getGoLyrics(source_platform: SourcePlatform, source_track_id: string): Promise<{ lyrics: Lyric[], lastUpdatedAt: number } | null> {
+    private async _getBoiduLyrics(tableName: string, source_platform: SourcePlatform, source_track_id: string): Promise<{ lyrics: Lyric[], lastUpdatedAt: number } | null> {
+        // Warning: tableName must be sanitized. Since we only pass hardcoded table names, it's safe.
         const stmt = this.env.DB.prepare(`
-            SELECT r2_key, last_accessed_at, last_updated_at FROM go_lyrics_cache WHERE video_id = ?1 AND source_platform = ?2
+            SELECT r2_key, last_accessed_at, last_updated_at FROM ${tableName} WHERE video_id = ?1 AND source_platform = ?2
         `);
         const result = await stmt.bind(source_track_id, source_platform).first<{ r2_key: string, last_accessed_at: number, last_updated_at: number }>();
 
@@ -140,7 +141,7 @@ export class CacheService {
         const now = Math.floor(Date.now() / 1000);
         if (now - result.last_accessed_at > 86400) {
              addAwait(
-                this.env.DB.prepare("UPDATE go_lyrics_cache SET last_accessed_at = ?1 WHERE video_id = ?2 AND source_platform = ?3")
+                this.env.DB.prepare(`UPDATE ${tableName} SET last_accessed_at = ?1 WHERE video_id = ?2 AND source_platform = ?3`)
                 .bind(now, source_track_id, source_platform).run()
             );
         }
@@ -155,15 +156,15 @@ export class CacheService {
         return { lyrics: [{ format: 'ttml', content }], lastUpdatedAt };
     }
 
-    async saveGoLyrics(data: SaveLyricsData): Promise<boolean> {
+    private async _saveBoiduLyrics(tableName: string, data: SaveLyricsData, providerName: string): Promise<boolean> {
         try {
             const compressed = pako.deflate(data.lyric_content);
-            const r2Key = `${data.source_track_id}/${data.lyric_format}.gz`;
+            const r2Key = `${data.source_track_id}/${providerName}_ttml.gz`;
             await this.env.LYRICS_BUCKET.put(r2Key, compressed);
 
             const now = Math.floor(Date.now() / 1000);
             await this.env.DB.prepare(`
-                INSERT INTO go_lyrics_cache (video_id, source_platform, r2_key, last_accessed_at, last_updated_at)
+                INSERT INTO ${tableName} (video_id, source_platform, r2_key, last_accessed_at, last_updated_at)
                 VALUES (?1, ?2, ?3, ?4, ?4)
                 ON CONFLICT(video_id, source_platform) DO UPDATE SET r2_key = ?3, last_accessed_at = ?4, last_updated_at = ?4
             `).bind(data.source_track_id, data.source_platform, r2Key, now).run();
@@ -171,6 +172,30 @@ export class CacheService {
         } catch (e) {
             return false;
         }
+    }
+
+    async getGoLyrics(source_platform: SourcePlatform, source_track_id: string) {
+        return this._getBoiduLyrics('go_lyrics_cache', source_platform, source_track_id);
+    }
+
+    async saveGoLyrics(data: SaveLyricsData) {
+        return this._saveBoiduLyrics('go_lyrics_cache', data, 'go');
+    }
+
+    async getQqLyrics(source_platform: SourcePlatform, source_track_id: string) {
+        return this._getBoiduLyrics('qq_lyrics_cache', source_platform, source_track_id);
+    }
+
+    async saveQqLyrics(data: SaveLyricsData) {
+        return this._saveBoiduLyrics('qq_lyrics_cache', data, 'qq');
+    }
+
+    async getKugouLyrics(source_platform: SourcePlatform, source_track_id: string) {
+        return this._getBoiduLyrics('kugou_lyrics_cache', source_platform, source_track_id);
+    }
+
+    async saveKugouLyrics(data: SaveLyricsData) {
+        return this._saveBoiduLyrics('kugou_lyrics_cache', data, 'kugou');
     }
 
     async getLrcLib(source_platform: SourcePlatform, source_track_id: string): Promise<{ synced: string | null, unsynced: string | null, lastUpdatedAt: number } | null> {
@@ -264,6 +289,8 @@ export class CacheService {
 
          // 2. Delete GoLyrics cache
          await this.env.DB.prepare("DELETE FROM go_lyrics_cache WHERE video_id = ?1").bind(videoId).run();
+         await this.env.DB.prepare("DELETE FROM qq_lyrics_cache WHERE video_id = ?1").bind(videoId).run();
+         await this.env.DB.prepare("DELETE FROM kugou_lyrics_cache WHERE video_id = ?1").bind(videoId).run();
 
          // 3. Delete YouTube metadata cache
          await this.env.DB.prepare("DELETE FROM youtube_cache WHERE video_id = ?1").bind(videoId).run();

--- a/src/services/LyricsService.ts
+++ b/src/services/LyricsService.ts
@@ -1,16 +1,17 @@
 import { Env } from '../types';
 import { MetadataService } from './MetadataService';
 import { Musixmatch } from '../providers/Musixmatch';
-import { GoLyricsApi } from '../providers/GoLyricsApi';
+import { BoiduLyricsApi } from '../providers/BoiduLyricsApi';
 import { LrcLib } from '../providers/LrcLib';
 import { observe } from '../observability';
-import { LyricsResponse } from '../LyricUtils'; // Interface
 import { isTruthy, sleep } from '../utils';
 
 export class LyricsService {
     private metadataService: MetadataService;
     private musixmatch: Musixmatch;
-    private goLyrics: GoLyricsApi;
+    private goLyrics: BoiduLyricsApi;
+    private qqLyrics: BoiduLyricsApi;
+    private kugouLyrics: BoiduLyricsApi;
     private lrcLib: LrcLib;
     private env: Env;
 
@@ -18,11 +19,13 @@ export class LyricsService {
         this.env = env;
         this.metadataService = new MetadataService(env);
         this.musixmatch = new Musixmatch(env);
-        this.goLyrics = new GoLyricsApi(env);
+        this.goLyrics = new BoiduLyricsApi(env, 'golyrics', 'https://lyrics-api.boidu.dev/getLyrics');
+        this.qqLyrics = new BoiduLyricsApi(env, 'qq', 'https://lyrics-api.boidu.dev/qq/getLyrics');
+        this.kugouLyrics = new BoiduLyricsApi(env, 'kugou', 'https://lyrics-api.boidu.dev/kugou/getLyrics');
         this.lrcLib = new LrcLib(env);
     }
 
-    async getLyrics(params: URLSearchParams): Promise<LyricsResponse | any> { // Type 'any' for the unified response object structure
+    async getLyrics(params: URLSearchParams): Promise<any> { // Type 'any' for the unified response object structure
         let artist: string | null | undefined = params.get('artist');
         let song: string | null | undefined = params.get('song');
         let album: string | null | undefined = params.get('album');
@@ -76,12 +79,13 @@ export class LyricsService {
             parsedSongAndArtist,
             videoId,
             description,
-            debugInfo: null as any,
             musixmatchWordByWordLyrics: null as any,
             musixmatchSyncedLyrics: null as any,
             lrclibSyncedLyrics: null as any,
             lrclibPlainLyrics: null as any,
-            goLyricsApiTtml: null as any
+            goLyricsApiLyrics: null as any,
+            qqLyricsApiLyrics: null as any,
+            kugouLyricsApiLyrics: null as any
         };
 
         let artistAlbumSongCombos: { artist: string, song: string, album: string | null }[] = [
@@ -89,7 +93,6 @@ export class LyricsService {
                 artist: artists.join(', '), album: album || null, song
             }
         ];
-        // Note: The commented out combos in GetLyrics.ts are skipped here too.
 
         let foundStats = [];
         for (let index in artistAlbumSongCombos) {
@@ -114,32 +117,36 @@ export class LyricsService {
                     if (lyrics) {
                         response.musixmatchWordByWordLyrics = lyrics.richSynced;
                         response.musixmatchSyncedLyrics = lyrics.synced;
-                        response.debugInfo = lyrics.debugInfo;
                     }
                 })
                 .catch(e => {
                     mxmError = e;
                 });
 
-            // GoLyrics
-            let goLyrics;
+            // Boidu sources
+            let boiduPromises = [];
             if (duration) {
-                goLyrics = this.goLyrics.getLrc(videoId, {
+                const boiduParams = {
                     song: combo.song,
                     artist: combo.artist,
                     album: combo.album,
                     duration: duration
-                }).then(lyrics => {
-                    if (lyrics) {
-                        response.goLyricsApiTtml = lyrics.ttml;
-                    }
-                });
+                };
+                boiduPromises.push(this.goLyrics.getLrc(videoId, boiduParams).then(lyrics => {
+                    if (lyrics) response.goLyricsApiLyrics = lyrics.lyrics;
+                }));
+                boiduPromises.push(this.qqLyrics.getLrc(videoId, boiduParams).then(lyrics => {
+                    if (lyrics) response.qqLyricsApiLyrics = lyrics.lyrics;
+                }));
+                boiduPromises.push(this.kugouLyrics.getLrc(videoId, boiduParams).then(lyrics => {
+                    if (lyrics) response.kugouLyricsApiLyrics = lyrics.lyrics;
+                }));
             }
 
-            await Promise.all([goLyrics, musixmatchLyrics]);
+            await Promise.all([...boiduPromises, musixmatchLyrics]);
 
             let lrcLibTimeout;
-            if (response.goLyricsApiTtml) {
+            if (response.goLyricsApiLyrics || response.qqLyricsApiLyrics || response.kugouLyricsApiLyrics) {
                 lrcLibTimeout = 4;
             } else {
                 lrcLibTimeout = 0.5;
@@ -151,11 +158,14 @@ export class LyricsService {
                 'hasLrcLibSynced': isTruthy(response.lrclibSyncedLyrics),
                 'hasMusixmatchSynced': isTruthy(response.musixmatchSyncedLyrics),
                 'hasLrcLibPlain': isTruthy(response.lrclibPlainLyrics),
-                'hasGoLyricsApiTtml': isTruthy(response.goLyricsApiTtml),
+                'hasGoLyricsApiLyrics': isTruthy(response.goLyricsApiLyrics),
+                'hasQqLyricsApiLyrics': isTruthy(response.qqLyricsApiLyrics),
+                'hasKugouLyricsApiLyrics': isTruthy(response.kugouLyricsApiLyrics),
                 'musixMatchError': mxmError
             });
 
-            if (isTruthy(response.musixmatchWordByWordLyrics) || isTruthy(response.lrclibSyncedLyrics) || isTruthy(response.musixmatchSyncedLyrics) || isTruthy(response.goLyricsApiTtml)) {
+            if (isTruthy(response.musixmatchWordByWordLyrics) || isTruthy(response.lrclibSyncedLyrics) || isTruthy(response.musixmatchSyncedLyrics) || 
+                isTruthy(response.goLyricsApiLyrics) || isTruthy(response.qqLyricsApiLyrics) || isTruthy(response.kugouLyricsApiLyrics)) {
                 response.song = combo.song;
                 response.artist = combo.artist;
                 response.album = combo.album;
@@ -163,14 +173,17 @@ export class LyricsService {
             }
         }
 
+        const hasAnySynced = isTruthy(response.musixmatchWordByWordLyrics) || isTruthy(response.lrclibSyncedLyrics) || 
+                             isTruthy(response.musixmatchSyncedLyrics) || isTruthy(response.goLyricsApiLyrics) || 
+                             isTruthy(response.qqLyricsApiLyrics) || isTruthy(response.kugouLyricsApiLyrics);
+
         observe({
             combos: artistAlbumSongCombos,
             foundStats: foundStats,
-            foundSyncedLyrics: isTruthy(response.musixmatchWordByWordLyrics) || isTruthy(response.lrclibSyncedLyrics) || isTruthy(response.musixmatchSyncedLyrics) || isTruthy(response.goLyricsApiTtml),
+            foundSyncedLyrics: hasAnySynced,
             foundPlainLyrics: isTruthy(response.lrclibPlainLyrics),
             foundRichSyncedLyrics: isTruthy(response.musixmatchSyncedLyrics),
-            foundTtml: isTruthy(response.goLyricsApiTtml),
-            foundLyrics: isTruthy(response.musixmatchWordByWordLyrics) || isTruthy(response.lrclibSyncedLyrics) || isTruthy(response.musixmatchSyncedLyrics) || isTruthy(response.lrclibPlainLyrics) || isTruthy(response.goLyricsApiTtml),
+            foundLyrics: hasAnySynced || isTruthy(response.lrclibPlainLyrics),
             response: response
         });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,12 +9,13 @@ export const LyricsResponseSchema = z.object({
   parsedSongAndArtist: z.string().nullable(),
   videoId: z.string().nullable(),
   description: z.string().nullable(),
-  debugInfo: z.any().nullable(),
   musixmatchWordByWordLyrics: z.any().nullable(),
   musixmatchSyncedLyrics: z.any().nullable(),
   lrclibSyncedLyrics: z.any().nullable(),
   lrclibPlainLyrics: z.any().nullable(),
-  goLyricsApiTtml: z.any().nullable(),
+  goLyricsApiLyrics: z.any().nullable(),
+  qqLyricsApiLyrics: z.any().nullable(),
+  kugouLyricsApiLyrics: z.any().nullable(),
 });
 
 export type LyricsResponse = z.infer<typeof LyricsResponseSchema>;


### PR DESCRIPTION
### TL;DR

Added support for QQ and Kugou lyrics providers alongside the existing GoLyrics provider, with dedicated database caching for each service.

### What changed?

- Created database migration to add `qq_lyrics_cache` and `kugou_lyrics_cache` tables
- Refactored `GoLyricsApi` into a generic `BoiduLyricsApi` class that supports multiple endpoints (GoLyrics, QQ, Kugou)
- Added cache methods in `CacheService` for QQ and Kugou lyrics with shared implementation
- Updated lyrics response structure to include separate fields for each provider (`goLyricsApiLyrics`, `qqLyricsApiLyrics`, `kugouLyricsApiLyrics`)
- Removed the generic `LyricsResponse` interface in favor of provider-specific response types
- Modified cache control logic to include new providers when determining cache duration
- Updated observability tracking to monitor all three Boidu-based providers

### How to test?

1. Run the database migration to create the new cache tables
2. Make requests to the lyrics endpoint with song metadata
3. Verify that responses now include separate fields for GoLyrics, QQ, and Kugou results
4. Check that caching works independently for each provider
5. Confirm that cache invalidation clears all three provider caches

### Why make this change?

This change expands the lyrics sources available to users by adding QQ and Kugou providers, which may have different coverage and quality for various songs. The refactoring allows for easy addition of new Boidu-based providers while maintaining separate caching strategies for optimal performance.